### PR TITLE
Add enabled/disabled state

### DIFF
--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -4,6 +4,7 @@ import emoji from '../../common/util/emoji';
 import Page from 'flarum/components/Page';
 import Select from 'flarum/components/Select';
 import saveSettings from 'flarum/utils/saveSettings';
+import Checkbox from 'flarum/components/Checkbox';
 
 export default class SettingsPage extends Page {
     init() {
@@ -88,6 +89,12 @@ export default class SettingsPage extends Page {
                                                 onclick: this.deleteReaction.bind(this, reaction),
                                             })}
                                             {demos}
+                                            {Checkbox.component({
+                                                className: 'Reactions-checkbox',
+                                                state: reaction.enabled(),
+                                                children: app.translator.trans('fof-reactions.admin.page.reactions.Enabledtext'),
+                                                onchange: this.updateStatus.bind(this, reaction),
+                                            })}
                                         </div>,
                                     ];
                                 })}
@@ -240,6 +247,7 @@ export default class SettingsPage extends Page {
                 identifier: m.prop(response.data.attributes.identifier),
                 type: m.prop(response.data.attributes.type),
                 id: m.prop(response.data.id),
+                enabled: m.prop(response.data.attributes.enabled),
             });
 
             this.newReaction.identifier('');
@@ -288,6 +296,22 @@ export default class SettingsPage extends Page {
         this.reactions.some((reaction, i) => {
             if (reaction.id() === reactionToDelete.id()) {
                 this.reactions.splice(i, 1);
+                return true;
+            }
+        });
+    }
+
+    updateStatus(reactionToUpdate, value) {
+        app.request({
+            method: 'PATCH',
+            url: app.forum.attribute('apiUrl') + '/reactions/' + reactionToUpdate.id(),
+            data: {
+                enabled: value,
+            },
+        });
+        this.reactions.some((reaction, i) => {
+            if (reaction.id() === reactionToUpdate.id()) {
+                reaction.enabled = m.prop(value);
                 return true;
             }
         });

--- a/js/src/common/models/Reaction.js
+++ b/js/src/common/models/Reaction.js
@@ -6,4 +6,5 @@ export default class Reaction extends mixin(Model, {
     type: Model.attribute('type'),
     user_id: Model.attribute('user_id'),
     post_id: Model.attribute('post_id'),
+    enabled: Model.attribute('enabled'),
 }) {}

--- a/js/src/forum/components/PostReactAction.js
+++ b/js/src/forum/components/PostReactAction.js
@@ -37,6 +37,10 @@ export default class PostReactAction extends Component {
         app.forum.reactions().forEach(reaction => {
             let buttonLabel;
 
+            if (reaction.enabled() === 0) {
+                return;
+            }
+
             if (reaction.type() === 'emoji') {
                 const url = this.names[reaction.identifier()];
                 buttonLabel = (

--- a/migrations/2019_12_13_120237_add_enabled_column_to_reactions_table.php
+++ b/migrations/2019_12_13_120237_add_enabled_column_to_reactions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) 2019 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+
+        $schema->table('reactions', function (Blueprint $table) {
+            $table->boolean('enabled')->default(true);
+        });
+
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('reactions', function (Blueprint $table) {
+            $table->dropColumn('enabled');
+        });
+    },
+];

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -71,4 +71,9 @@
     padding-right: 9px;
     vertical-align: middle;
   }
+  .Reactions-checkbox {
+    padding-left: 25px;
+    vertical-align: middle;
+    display: inline-block;
+  }
 }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -14,6 +14,7 @@ fof-reactions:
 
     page:
       reactions:
+        Enabledtext: Enable
         title: Custom Reactions
         reactions: Current Reactions
         Helptext: Input the name (identifier) of the emoji or font-awesome icon and select which type you would like.

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,5 +1,6 @@
 fof-reactions:
   forum:
+    disabled-reaction: You can't use this reaction right now, please refresh the page
     warning: Your reaction was converted
     notification: '{username} reacted with {reaction} to your post'
     settings:

--- a/src/Api/Serializer/ReactionSerializer.php
+++ b/src/Api/Serializer/ReactionSerializer.php
@@ -28,6 +28,7 @@ class ReactionSerializer extends AbstractSerializer
         return [
             'identifier' => $reaction->identifier,
             'type'       => $reaction->type,
+            'enabled'    => $reaction->enabled,
         ];
     }
 }

--- a/src/Command/EditReactionHandler.php
+++ b/src/Command/EditReactionHandler.php
@@ -57,6 +57,10 @@ class EditReactionHandler
             $reaction->type = $data['type'];
         }
 
+        if (isset($data['enabled'])) {
+            $reaction->enabled = $data['enabled'];
+        }
+
         $this->validator->assertValid($reaction->getDirty());
 
         $reaction->save();

--- a/src/Reaction.php
+++ b/src/Reaction.php
@@ -29,11 +29,12 @@ class Reaction extends AbstractModel
      *
      * @return static
      */
-    public static function build($identifier, $type)
+    public static function build($identifier, $type, $enabled = true)
     {
         $reaction = new static();
         $reaction->identifier = $identifier;
         $reaction->type = $type;
+        $reaction->enabled = $enabled;
 
         return $reaction;
     }


### PR DESCRIPTION
Adding enabled/disabled state, so that seasonal or temporary reactions can be used, and remain visible on posts after they are disabled