### PR TITLE
Prevent user from reacting to own post

### DIFF
--- a/js/src/forum/addReactionAction.js
+++ b/js/src/forum/addReactionAction.js
@@ -7,7 +7,7 @@ export default () => {
     extend(CommentPost.prototype, 'actionItems', function(items) {
         const post = this.props.post;
 
-        if (post.isHidden() || post.user() === app.session.user) return;
+        if (post.isHidden()) return;
 
         const reaction = app.session.user && Array.isArray(post.reactions()) && post.reactions().some(user => user === app.session.user);
 

--- a/js/src/forum/addReactionAction.js
+++ b/js/src/forum/addReactionAction.js
@@ -7,7 +7,7 @@ export default () => {
     extend(CommentPost.prototype, 'actionItems', function(items) {
         const post = this.props.post;
 
-        if (post.isHidden()) return;
+        if (post.isHidden() || post.user() === app.session.user) return;
 
         const reaction = app.session.user && Array.isArray(post.reactions()) && post.reactions().some(user => user === app.session.user);
 

--- a/js/src/forum/components/PostReactAction.js
+++ b/js/src/forum/components/PostReactAction.js
@@ -147,7 +147,7 @@ export default class PostReactAction extends Component {
 
     reactButton() {
         if (this.post.user() === app.session.user) {
-            return ('');
+            return;
         }
         return (
             <button className="Button Button--link Reactions--ShowReactions" type="Button" title="React">

--- a/js/src/forum/components/PostReactAction.js
+++ b/js/src/forum/components/PostReactAction.js
@@ -128,7 +128,7 @@ export default class PostReactAction extends Component {
                     return [
                         <span
                             className="Button-label Button-emoji-parent"
-                            onclick={el => this.react(this.reaction ? identifier : el)}
+                            onclick={this.post.user() !== app.session.user ? (el => this.react(this.reaction ? identifier : el)) : ''}
                             data-reaction={identifier}
                         >
                             {icon}
@@ -136,7 +136,7 @@ export default class PostReactAction extends Component {
                         </span>,
                     ];
                 })}
-                {!this.reaction ? (
+                {!this.reaction && this.post.user() !== app.session.user ? (
                     <div className="CommentPost--Reactions" style={this.post.number() === 1 ? '' : 'left: -28%;'}>
                         <ul className="Reactions--Ul">{listItems(this.getReactions().toArray())}</ul>
                     </div>
@@ -146,6 +146,9 @@ export default class PostReactAction extends Component {
     }
 
     reactButton() {
+        if (this.post.user() === app.session.user) {
+            return ('');
+        }
         return (
             <button className="Button Button--link Reactions--ShowReactions" type="Button" title="React">
                 <span className="Button-label" style={this.reaction ? 'display: none' : 'display:'}>

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -5,6 +5,7 @@ fof-reactions:
     notification: '{username} reacted with {reaction} to your post'
     settings:
         notify_post_reacted_label: Someone reacts to one of my posts
+    reacting-own-post: You cannot react to your own post
 
   admin:
     permissions:

--- a/src/Listener/SaveReactionsToDatabase.php
+++ b/src/Listener/SaveReactionsToDatabase.php
@@ -74,7 +74,7 @@ class SaveReactionsToDatabase
 
             if ($actor->id === $post->user_id) {
                 throw new ValidationException([
-                    'message' => $this->translator->trans('fof-reactions.forum.reacting-own-post')
+                    'message' => $this->translator->trans('fof-reactions.forum.reacting-own-post'),
                 ]);
             }
 

--- a/src/Listener/SaveReactionsToDatabase.php
+++ b/src/Listener/SaveReactionsToDatabase.php
@@ -59,6 +59,7 @@ class SaveReactionsToDatabase
      * @param Saving $event
      *
      * @throws \Flarum\User\Exception\PermissionDeniedException
+     * @throws \Flarum\Foundation\ValidationException
      */
     public function whenSaving(Saving $event)
     {
@@ -70,6 +71,12 @@ class SaveReactionsToDatabase
             $reactionType = $data['attributes']['reaction'];
 
             $this->assertCan($actor, 'react', $post);
+
+            if ($actor->id === $post->user_id) {
+                throw new ValidationException([
+                    'message' => $this->translator->trans('fof-reactions.forum.reacting-own-post')
+                ]);
+            }
 
             $this->validateReaction($reactionType);
 


### PR DESCRIPTION
It does not make sense for a user to react to their own post. This PR checks for this by:

- Remove the reaction action from posts made by the session user (FE)
- Performs an additional validation before attempting to save (BE)