### PR TITLE
Fix notifications for [deleted] users

### DIFF
--- a/src/Listener/SendNotifications.php
+++ b/src/Listener/SendNotifications.php
@@ -53,7 +53,7 @@ class SendNotifications
      */
     public function sync(Post $post, User $user, $reaction, array $recipients)
     {
-        if (null !== $post->user && $post->user->id != $user->id) {
+        if ($post->user && $post->user->id != $user->id) {
             app(NotificationSyncer::class)->sync(
                 new PostReactedBlueprint($post, $user, $reaction),
                 $recipients

--- a/src/Listener/SendNotifications.php
+++ b/src/Listener/SendNotifications.php
@@ -53,7 +53,7 @@ class SendNotifications
      */
     public function sync(Post $post, User $user, $reaction, array $recipients)
     {
-        if ($post->user->id != $user->id) {
+        if (null !== $post->user && $post->user->id != $user->id) {
             app(NotificationSyncer::class)->sync(
                 new PostReactedBlueprint($post, $user, $reaction),
                 $recipients


### PR DESCRIPTION
Currently when one reacts to a `[deleted]` user's post, it will throw an exception. This should fix it.