### PR TITLE
Fix Mithril crash with Pusher. Add Pusher binding for unreacting.

### DIFF
--- a/src/Listener/SaveReactionsToDatabase.php
+++ b/src/Listener/SaveReactionsToDatabase.php
@@ -122,6 +122,8 @@ class SaveReactionsToDatabase
                         $oldReaction->reaction_id = null;
                         $oldReaction->save();
 
+                        $this->pushRemovedReaction($actor, $post, $reactionType);
+
                         $post->raise(new PostWasUnreacted($post, $actor));
                     }
                 } else {
@@ -153,6 +155,24 @@ class SaveReactionsToDatabase
                 'identifier' => $identifier,
             ]);
         }
+    }
+
+    /**
+     * @param $actor
+     * @param $post
+     * @param $identifier
+     *
+     * @throws \Pusher\PusherException
+     */
+    public function pushRemovedReaction($actor, $post, $identifier)
+    {
+        if ($pusher = $this->getPusher()) {
+            $pusher->trigger('public', 'removedReaction', [
+                'postId'     => $post->id,
+                'userId'     => $actor->id,
+                'identifier' => $identifier,
+            ]);
+        } 
     }
 
     /**


### PR DESCRIPTION
Added a line of code in `js/src/forum/components/index.js` that prevents a Mithril crash when Pusher pushes data which doesn't include a `user_id` property when reacting for the first time.

Also added a Pusher event in `src/Listener/SaveReactionsToDatabase.php` when removing post reactions, as the when
1. reacting
2. removing the reaction
3. reacting again

would duplicate the display of reactions until a refresh.