### PR TITLE
Use emoji icon in notification settings

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -32,7 +32,7 @@ app.initializers.add('fof/reactions', () => {
     extend(NotificationGrid.prototype, 'notificationTypes', (items) => {
         items.add('postReacted', {
             name: 'postReacted',
-            icon: 'fas fa-eye',
+            icon: 'far fa-smile',
             label: app.translator.trans('fof-reactions.forum.settings.notify_post_reacted_label'),
         });
     });


### PR DESCRIPTION
The eye icon doesn't really match "reactions" at a glance. I think a smile icon (or similar) would suit it much more nicely.