### PR TITLE
Workaround for invalid reaction ID

### DIFF
--- a/js/src/forum/components/PostReactAction.js
+++ b/js/src/forum/components/PostReactAction.js
@@ -68,7 +68,7 @@ export default class PostReactAction extends Component {
                         const reaction = app.store.getById('reactions', id);
                         const count = groupedPostReactions[id].length;
 
-                        if (count === 0) return;
+                        if (count === 0 || typeof reaction === 'undefined') return;
 
                         const spanClass = reaction.type() === 'icon' ? `${reaction.identifier()} emoji button-emoji reaction-icon` : '';
                         const icon = <ReactionComponent reaction={reaction} className={spanClass} data-reaction={reaction.identifier()} />;


### PR DESCRIPTION
Honestly, I have no clue why this happens.

You can see the issue present [here](https://community.giffgaff.com/d/33056870-music-you-liked-while-growing-up) where an invalid ID (`9`) is attempted to be fetched from the app store, but as there are only 6 reactions, it returns `undefined`. When the code then calls `reaction.type()`, an exception is thrown as it can't call `.type()` of `undefined`.

This then causes the infinite scrolling to break completely, rendering anything past the first 5 posts useless.

It's possible that when an old reaction was removed, it wasn't cleaned up properly, or some other weird issue happened during a migration.

Either way, this *should* act as a workaround for the problem until a real cause and solution can be found.