### PR TITLE
fix: migrations assume flarum is already installed

### DIFF
--- a/migrations/2019_07_08_000003_migrate_extension_settings.php
+++ b/migrations/2019_07_08_000003_migrate_extension_settings.php
@@ -13,18 +13,14 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        /**
-         * @var \Flarum\Settings\SettingsRepositoryInterface
-         */
-        $settings = resolve('flarum.settings');
+        $db = $schema->getConnection();
 
         $keys = ['convertToUpvote', 'convertToDownvote', 'convertToLike'];
 
         foreach ($keys as $key) {
-            if ($value = $settings->get($full = "reflar.reactions.$key")) {
-                $settings->set("fof-reactions.$key", $value);
-                $settings->delete($full);
-            }
+            $db->table('settings')
+                ->where('key', "reflar.reactions.$key")
+                ->update(['key' => "fof-reactions.$key"]);
         }
     },
 ];


### PR DESCRIPTION
**Relates to https://github.com/flarum/framework/pull/3655**

**Changes proposed in this pull request:**
The current migrations assume Flarum is already installed and resolve dependencies that are only available then. This makes it impossible to directly install an instance with the extension. This PR makes sure the database connection provided is the one used to make the needed changes without resolving anything else.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
