### PR TITLE
Add the `PostReaction` object to events

### DIFF
--- a/src/Event/PostWasReacted.php
+++ b/src/Event/PostWasReacted.php
@@ -13,6 +13,7 @@ namespace FoF\Reactions\Event;
 
 use Flarum\Post\Post;
 use Flarum\User\User;
+use FoF\Reactions\PostReaction;
 use FoF\Reactions\Reaction;
 
 class PostWasReacted
@@ -21,6 +22,11 @@ class PostWasReacted
      * @var Post
      */
     public $post;
+
+    /**
+     * @var PostReaction
+     */
+    public $postReaction;
 
     /**
      * @var User
@@ -41,13 +47,15 @@ class PostWasReacted
      * PostWasReacted constructor.
      *
      * @param Post $post
+     * @param PostReaction $postReaction
      * @param User $user
-     * @param $reaction
+     * @param Reaction $reaction
      * @param bool $changed
      */
-    public function __construct(Post $post, User $user, Reaction $reaction, $changed = false)
+    public function __construct(Post $post, PostReaction $postReaction, User $user, Reaction $reaction, $changed = false)
     {
         $this->post = $post;
+        $this->postReaction = $postReaction;
         $this->user = $user;
         $this->reaction = $reaction;
         $this->changed = $changed;

--- a/src/Event/PostWasReacted.php
+++ b/src/Event/PostWasReacted.php
@@ -46,11 +46,11 @@ class PostWasReacted
     /**
      * PostWasReacted constructor.
      *
-     * @param Post $post
+     * @param Post         $post
      * @param PostReaction $postReaction
-     * @param User $user
-     * @param Reaction $reaction
-     * @param bool $changed
+     * @param User         $user
+     * @param Reaction     $reaction
+     * @param bool         $changed
      */
     public function __construct(Post $post, PostReaction $postReaction, User $user, Reaction $reaction, $changed = false)
     {

--- a/src/Event/PostWasUnreacted.php
+++ b/src/Event/PostWasUnreacted.php
@@ -13,6 +13,7 @@ namespace FoF\Reactions\Event;
 
 use Flarum\Post\Post;
 use Flarum\User\User;
+use FoF\Reactions\PostReaction;
 
 class PostWasUnreacted
 {
@@ -22,17 +23,24 @@ class PostWasUnreacted
     public $post;
 
     /**
+     * @var PostReaction
+     */
+    public $postReaction;
+
+    /**
      * @var User
      */
     public $user;
 
     /**
      * @param Post $post
+     * @param PostReaction $postReaction
      * @param User $user
      */
-    public function __construct(Post $post, User $user)
+    public function __construct(Post $post, PostReaction $postReaction, User $user)
     {
         $this->post = $post;
+        $this->postReaction = $postReaction;
         $this->user = $user;
     }
 }

--- a/src/Event/PostWasUnreacted.php
+++ b/src/Event/PostWasUnreacted.php
@@ -33,9 +33,9 @@ class PostWasUnreacted
     public $user;
 
     /**
-     * @param Post $post
+     * @param Post         $post
      * @param PostReaction $postReaction
-     * @param User $user
+     * @param User         $user
      */
     public function __construct(Post $post, PostReaction $postReaction, User $user)
     {

--- a/src/Listener/SaveReactionsToDatabase.php
+++ b/src/Listener/SaveReactionsToDatabase.php
@@ -125,7 +125,7 @@ class SaveReactionsToDatabase
                         $postReaction->save();
                     }
 
-                    $post->raise(new PostWasUnreacted($post, $actor));
+                    $post->raise(new PostWasUnreacted($post, $postReaction, $actor));
                 } else {
                     $this->validateReaction($reactionId);
 
@@ -144,7 +144,7 @@ class SaveReactionsToDatabase
 
                     $this->push('newReaction', $postReaction, $reaction, $actor, $post);
 
-                    $post->raise(new PostWasReacted($post, $actor, $reaction));
+                    $post->raise(new PostWasReacted($post, $postReaction, $actor, $reaction));
                 }
             }
         }


### PR DESCRIPTION
**Changes proposed in this pull request:**
To make it possible to know when the reaction has happened, when listening to events, one needs to have access to the `PostReaction` object. This was added easily and shouldn't have any negative side effects.

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
