### PR TITLE
feat: Anonymous (optionally) reactions

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -19,7 +19,6 @@ use Flarum\Extend;
 use Flarum\Post\Event\Saving;
 use Flarum\Post\Post;
 use FoF\Reactions\Api\Controller;
-use FoF\Reactions\Api\Serializer\PostReactionSerializer;
 use FoF\Reactions\Api\Serializer\ReactionSerializer;
 use FoF\Reactions\Notification\PostReactedBlueprint;
 

--- a/extend.php
+++ b/extend.php
@@ -71,8 +71,8 @@ return [
 
     (new Extend\Settings())
         ->default('fof-reactions.react_own_post', false)
-        ->default('fof-reactions.allow-anonymous', false)
-        ->serializeToForum('fofReactionsAllowAnonymous', 'fof-reactions.allow-anonymous'),
+        ->default('fof-reactions.anonymousReactions', false)
+        ->serializeToForum('fofReactionsAllowAnonymous', 'fof-reactions.anonymousReactions'),
 
     (new Extend\Policy())
         ->modelPolicy(Post::class, Access\ReactPostPolicy::class),

--- a/extend.php
+++ b/extend.php
@@ -19,6 +19,7 @@ use Flarum\Extend;
 use Flarum\Post\Event\Saving;
 use Flarum\Post\Post;
 use FoF\Reactions\Api\Controller;
+use FoF\Reactions\Api\Serializer\PostReactionSerializer;
 use FoF\Reactions\Api\Serializer\ReactionSerializer;
 use FoF\Reactions\Notification\PostReactedBlueprint;
 

--- a/extend.php
+++ b/extend.php
@@ -71,7 +71,7 @@ return [
 
     (new Extend\Settings())
         ->default('fof-reactions.react_own_post', false)
-        ->default('fof-reactions.allow-anonymous', true)
+        ->default('fof-reactions.allow-anonymous', false)
         ->serializeToForum('fofReactionsAllowAnonymous', 'fof-reactions.allow-anonymous'),
 
     (new Extend\Policy())

--- a/extend.php
+++ b/extend.php
@@ -19,7 +19,6 @@ use Flarum\Extend;
 use Flarum\Post\Event\Saving;
 use Flarum\Post\Post;
 use FoF\Reactions\Api\Controller;
-use FoF\Reactions\Api\Serializer\PostReactionSerializer;
 use FoF\Reactions\Api\Serializer\ReactionSerializer;
 use FoF\Reactions\Notification\PostReactedBlueprint;
 
@@ -41,21 +40,12 @@ return [
         ->patch('/reactions/{id}', 'reactions.update', Controller\UpdateReactionController::class)
         ->delete('/reactions/{id}', 'reactions.delete', Controller\DeleteReactionController::class),
 
-    // (new Extend\Model(Post::class))
-    //     ->relationship('reactions', function (AbstractModel $model) {
-    //         return $model->hasMany(PostReaction::class, 'post_id')
-    //             ->whereNotNull('reaction_id');
-    //     }),
-
     (new Extend\Event())
         ->listen(Saving::class, Listener\SaveReactionsToDatabase::class)
         ->subscribe(Listener\SendNotifications::class),
 
     (new Extend\Notification())
         ->type(PostReactedBlueprint::class, BasicPostSerializer::class, ['alert']),
-
-    // (new Extend\ApiSerializer(Serializer\BasicPostSerializer::class))
-    //     ->hasMany('reactions', PostReactionSerializer::class),
 
     (new Extend\ApiSerializer(Serializer\ForumSerializer::class))
         ->hasMany('reactions', ReactionSerializer::class)
@@ -76,27 +66,8 @@ return [
             $data['reactions'] = Reaction::get();
         }),
 
-    // (new Extend\ApiController(ApiController\ListDiscussionsController::class))
-    //     ->addOptionalInclude('firstPost.reactions'),
-
-    // (new Extend\ApiController(ApiController\ShowDiscussionController::class))
-    //     ->addInclude('posts.reactions')
-    //     ->addOptionalInclude('firstPost.reactions'),
-
     (new Extend\ApiController(ApiController\ShowForumController::class))
         ->addInclude('reactions'),
-
-    // (new Extend\ApiController(ApiController\ListPostsController::class))
-    //     ->addInclude('reactions'),
-
-    // (new Extend\ApiController(ApiController\ShowPostController::class))
-    //     ->addInclude('reactions'),
-
-    // (new Extend\ApiController(ApiController\CreatePostController::class))
-    //     ->addInclude('reactions'),
-
-    // (new Extend\ApiController(ApiController\UpdatePostController::class))
-    //     ->addInclude('reactions'),
 
     (new Extend\Settings())
         ->default('fof-reactions.react_own_post', false)

--- a/extend.php
+++ b/extend.php
@@ -41,11 +41,11 @@ return [
         ->patch('/reactions/{id}', 'reactions.update', Controller\UpdateReactionController::class)
         ->delete('/reactions/{id}', 'reactions.delete', Controller\DeleteReactionController::class),
 
-    (new Extend\Model(Post::class))
-        ->relationship('reactions', function (AbstractModel $model) {
-            return $model->hasMany(PostReaction::class, 'post_id')
-                ->whereNotNull('reaction_id');
-        }),
+    // (new Extend\Model(Post::class))
+    //     ->relationship('reactions', function (AbstractModel $model) {
+    //         return $model->hasMany(PostReaction::class, 'post_id')
+    //             ->whereNotNull('reaction_id');
+    //     }),
 
     (new Extend\Event())
         ->listen(Saving::class, Listener\SaveReactionsToDatabase::class)
@@ -54,19 +54,15 @@ return [
     (new Extend\Notification())
         ->type(PostReactedBlueprint::class, BasicPostSerializer::class, ['alert']),
 
-    (new Extend\ApiSerializer(Serializer\BasicPostSerializer::class))
-        ->hasMany('reactions', PostReactionSerializer::class),
+    // (new Extend\ApiSerializer(Serializer\BasicPostSerializer::class))
+    //     ->hasMany('reactions', PostReactionSerializer::class),
 
     (new Extend\ApiSerializer(Serializer\ForumSerializer::class))
         ->hasMany('reactions', ReactionSerializer::class)
         ->attributes(ReactionsForumAttributes::class),
 
     (new Extend\ApiSerializer(Serializer\PostSerializer::class))
-        ->attributes(function (Serializer\PostSerializer $serializer, AbstractModel $post, array $attributes): array {
-            $attributes['canReact'] = (bool) $serializer->getActor()->can('react', $post);
-
-            return $attributes;
-        }),
+        ->attributes(PostAttributes::class),
 
     (new Extend\ApiSerializer(Serializer\DiscussionSerializer::class))
         ->attributes(function (Serializer\DiscussionSerializer $serializer, AbstractModel $discussion, array $attributes): array {
@@ -80,31 +76,36 @@ return [
             $data['reactions'] = Reaction::get();
         }),
 
-    (new Extend\ApiController(ApiController\ListDiscussionsController::class))
-        ->addOptionalInclude('firstPost.reactions'),
+    // (new Extend\ApiController(ApiController\ListDiscussionsController::class))
+    //     ->addOptionalInclude('firstPost.reactions'),
 
-    (new Extend\ApiController(ApiController\ShowDiscussionController::class))
-        ->addInclude('posts.reactions')
-        ->addOptionalInclude('firstPost.reactions'),
+    // (new Extend\ApiController(ApiController\ShowDiscussionController::class))
+    //     ->addInclude('posts.reactions')
+    //     ->addOptionalInclude('firstPost.reactions'),
 
     (new Extend\ApiController(ApiController\ShowForumController::class))
         ->addInclude('reactions'),
 
-    (new Extend\ApiController(ApiController\ListPostsController::class))
-        ->addInclude('reactions'),
+    // (new Extend\ApiController(ApiController\ListPostsController::class))
+    //     ->addInclude('reactions'),
 
-    (new Extend\ApiController(ApiController\ShowPostController::class))
-        ->addInclude('reactions'),
+    // (new Extend\ApiController(ApiController\ShowPostController::class))
+    //     ->addInclude('reactions'),
 
-    (new Extend\ApiController(ApiController\CreatePostController::class))
-        ->addInclude('reactions'),
+    // (new Extend\ApiController(ApiController\CreatePostController::class))
+    //     ->addInclude('reactions'),
 
-    (new Extend\ApiController(ApiController\UpdatePostController::class))
-        ->addInclude('reactions'),
+    // (new Extend\ApiController(ApiController\UpdatePostController::class))
+    //     ->addInclude('reactions'),
 
     (new Extend\Settings())
-        ->default('fof-reactions.react_own_post', false),
+        ->default('fof-reactions.react_own_post', false)
+        ->default('fof-reactions.allow-anonymous', true)
+        ->serializeToForum('fofReactionsAllowAnonymous', 'fof-reactions.allow-anonymous'),
 
     (new Extend\Policy())
         ->modelPolicy(Post::class, Access\ReactPostPolicy::class),
+
+    (new Extend\Middleware('api'))
+        ->add(Middleware\BindRequestToContainer::class),
 ];

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -173,12 +173,12 @@ export default class SettingsPage extends ExtensionPage {
                   </Switch>
                   <div className="helpText">{app.translator.trans('fof-reactions.admin.page.settings.react_own_posts_help')}</div>
                 </div>
-                {this.buildSettingComponent({
-                  type: 'boolean',
-                  setting: 'fof-reactions.allow-anonymous',
-                  label: app.translator.trans('fof-reactions.admin.page.settings.allow-anonymous'),
-                  help: app.translator.trans('fof-reactions.admin.page.settings.allow-anonymous-help'),
-                })}
+                <div>
+                  <Switch state={this.values.anonymousReactions()} onchange={this.values.anonymousReactions} className="reactions-settings-switch">
+                    {app.translator.trans('fof-reactions.admin.page.settings.allow-anonymous')}
+                  </Switch>
+                  <div className="helpText">{app.translator.trans('fof-reactions.admin.page.settings.allow-anonymous-help')}</div>
+                </div>
                 {this.isExtEnabled('fof-gamification') || this.isExtEnabled('flarum-likes') ? (
                   <legend>{app.translator.trans('fof-reactions.admin.page.settings.integrations.legend')}</legend>
                 ) : (

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -15,7 +15,7 @@ export default class SettingsPage extends ExtensionPage {
 
     this.fields = ['convertToUpvote', 'convertToDownvote', 'convertToLike'];
 
-    this.switches = ['react_own_post'];
+    this.switches = ['react_own_post', 'anonymousReactions'];
 
     this.values = {};
 
@@ -173,6 +173,12 @@ export default class SettingsPage extends ExtensionPage {
                   </Switch>
                   <div className="helpText">{app.translator.trans('fof-reactions.admin.page.settings.react_own_posts_help')}</div>
                 </div>
+                {this.buildSettingComponent({
+                  type: 'boolean',
+                  setting: 'fof-reactions.allow-anonymous',
+                  label: app.translator.trans('fof-reactions.admin.page.settings.allow-anonymous'),
+                  help: app.translator.trans('fof-reactions.admin.page.settings.allow-anonymous-help'),
+                })}
                 {this.isExtEnabled('fof-gamification') || this.isExtEnabled('flarum-likes') ? (
                   <legend>{app.translator.trans('fof-reactions.admin.page.settings.integrations.legend')}</legend>
                 ) : (

--- a/js/src/forum/addReactionAction.js
+++ b/js/src/forum/addReactionAction.js
@@ -12,20 +12,23 @@ export default () => {
 
     if (post.isHidden()) return;
 
-    const reaction = app.session.user && Array.isArray(post.reactions()) && post.reactions().some((user) => user === app.session.user);
+    const hasReacted = app.session.user && post.userReaction() !== null;
 
     items.add(
       'react',
       PostReactAction.component({
         post,
-        reaction,
+        hasReacted,
       }),
       5
     );
   });
 
   extend(PostControls, 'moderationControls', function (items, post) {
-    if (post.discussion().canSeeReactions() && post.reactions() && post.reactions().length) {
+    const reactionCounts = post.reactionCounts();
+    const hasReactions = reactionCounts && Object.keys(reactionCounts).length > 0;
+
+    if (post.discussion().canSeeReactions() && hasReactions) {
       items.add(
         'viewReactions',
         <Button icon="fas fa-heart" onclick={() => app.modal.show(ReactionsModal, { post })}>

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -27,7 +27,8 @@ app.initializers.add('fof/reactions', () => {
   app.notificationComponents.postReacted = PostReactedNotification;
 
   Post.prototype.canReact = Model.attribute('canReact');
-  Post.prototype.reactions = Model.hasMany('reactions');
+  Post.prototype.reactionCounts = Model.attribute('reactionCounts');
+  Post.prototype.userReaction = Model.attribute('userReaction');
 
   Forum.prototype.reactions = Model.hasMany('reactions');
 

--- a/migrations/2023_07_05_000000_create_post_anonymous_reactions_table.php
+++ b/migrations/2023_07_05_000000_create_post_anonymous_reactions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        if ($schema->hasTable('post_anonymous_reactions')) {
+            return;
+        }
+
+        $schema->create('post_anonymous_reactions', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->integer('post_id')->unsigned();
+            $table->string('guest_id', 64)->index(); // using SHA256 for guest_id
+            $table->integer('reaction_id')->unsigned()->nullable();
+            $table->timestamps();
+
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->foreign('reaction_id')->references('id')->on('reactions')->onDelete('cascade');
+        });
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->dropIfExists('post_anonymous_reactions');
+    },
+];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -8,6 +8,7 @@ fof-reactions:
     reacting-own-post: You cannot react to your own post
     modal:
         title: Reactions
+        anonymous_count: "plus {count} anonymous users"
     mod_item: View Reactions
     react_button_label: React
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -34,7 +34,9 @@ fof-reactions:
 
       settings:
         react_own_posts_help: When enabled, subject to permission, users may react to their own posts on the forum. To prevent users reacting on their own posts, disable this setting.
-        react_own_posts_label: Users may react to their own posts
+        react_own_posts_label: Users may react to their own posts,
+        allow-anonymous: Allow anonymous(guest) reactions
+        allow-anonymous-help: If enabled, guests and anonymous users will be able to react to posts. Note that anonymous reactions will not be linked to a user profile and will be aggregated in the reactions list.
         save_settings: Save Settings
         integrations:
           legend: Integrations

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -8,7 +8,7 @@ fof-reactions:
     reacting-own-post: You cannot react to your own post
     modal:
         title: Reactions
-        anonymous_count: "plus {count} anonymous users"
+        anonymous_count: "{count, plural, one {# anonymous user} other {# anonymous users}}"
     mod_item: View Reactions
     react_button_label: React
 

--- a/src/Access/ReactPostPolicy.php
+++ b/src/Access/ReactPostPolicy.php
@@ -30,6 +30,10 @@ class ReactPostPolicy extends AbstractPolicy
 
     public function react(User $actor, Post $post)
     {
+        if ($actor->isGuest() && (bool) $this->settings->get('fof-reactions.allow-anonymous')) {
+            return $this->allow();
+        }
+
         if ($actor->id === $post->user_id && !(bool) $this->settings->get('fof-reactions.react_own_post')) {
             return $this->deny();
         }

--- a/src/Access/ReactPostPolicy.php
+++ b/src/Access/ReactPostPolicy.php
@@ -30,7 +30,7 @@ class ReactPostPolicy extends AbstractPolicy
 
     public function react(User $actor, Post $post)
     {
-        if ($actor->isGuest() && (bool) $this->settings->get('fof-reactions.allow-anonymous')) {
+        if ($actor->isGuest() && (bool) $this->settings->get('fof-reactions.anonymousReactions')) {
             return $this->allow();
         }
 

--- a/src/Api/Controller/ListPostReactionsController.php
+++ b/src/Api/Controller/ListPostReactionsController.php
@@ -1,16 +1,25 @@
 <?php
 
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Reactions\Api\Controller;
 
 use Flarum\Api\Controller\AbstractListController;
 use Flarum\Post\PostRepository;
+use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Reactions\Api\Serializer\PostReactionSerializer;
-use FoF\Reactions\PostReaction;
 use FoF\Reactions\PostAnonymousReaction;
+use FoF\Reactions\PostReaction;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
-use Flarum\Settings\SettingsRepositoryInterface;
 
 class ListPostReactionsController extends AbstractListController
 {

--- a/src/Api/Controller/ListPostReactionsController.php
+++ b/src/Api/Controller/ListPostReactionsController.php
@@ -1,22 +1,16 @@
 <?php
 
-/*
- * This file is part of fof/reactions.
- *
- * Copyright (c) FriendsOfFlarum.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FoF\Reactions\Api\Controller;
 
 use Flarum\Api\Controller\AbstractListController;
 use Flarum\Post\PostRepository;
 use FoF\Reactions\Api\Serializer\PostReactionSerializer;
+use FoF\Reactions\PostReaction;
+use FoF\Reactions\PostAnonymousReaction;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
+use Flarum\Settings\SettingsRepositoryInterface;
 
 class ListPostReactionsController extends AbstractListController
 {
@@ -31,9 +25,15 @@ class ListPostReactionsController extends AbstractListController
      */
     protected $posts;
 
-    public function __construct(PostRepository $posts)
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(PostRepository $posts, SettingsRepositoryInterface $settings)
     {
         $this->posts = $posts;
+        $this->settings = $settings;
     }
 
     /**
@@ -47,6 +47,21 @@ class ListPostReactionsController extends AbstractListController
         $postId = Arr::get($request->getQueryParams(), 'id');
         $post = $this->posts->findOrFail($postId, $request->getAttribute('actor'));
 
-        return $post->reactions()->whereNotNull('reaction_id')->get();
+        if ($this->settings->get('fof-reactions.allow-anonymous')) {
+            // If anonymous reactions are allowed, we union reactions from registered users and anonymous users
+            $query = PostReaction::where('post_id', $post->id)
+                ->whereNotNull('reaction_id')
+                ->unionAll(
+                    PostAnonymousReaction::where('post_id', $post->id)
+                        ->whereNotNull('reaction_id')
+                );
+        } else {
+            // If anonymous reactions are not allowed, we just get reactions from registered users.
+            $query = PostReaction::where('post_id', $post->id)
+                ->whereNotNull('reaction_id');
+        }
+
+        // Execute the query and return the result.
+        return $query->get();
     }
 }

--- a/src/Api/Controller/ListPostReactionsController.php
+++ b/src/Api/Controller/ListPostReactionsController.php
@@ -56,7 +56,7 @@ class ListPostReactionsController extends AbstractListController
         $postId = Arr::get($request->getQueryParams(), 'id');
         $post = $this->posts->findOrFail($postId, $request->getAttribute('actor'));
 
-        if ($this->settings->get('fof-reactions.allow-anonymous')) {
+        if ($this->settings->get('fof-reactions.anonymousReactions')) {
             // If anonymous reactions are allowed, we union reactions from registered users and anonymous users
             $query = PostReaction::where('post_id', $post->id)
                 ->whereNotNull('reaction_id')

--- a/src/Api/Serializer/PostReactionSerializer.php
+++ b/src/Api/Serializer/PostReactionSerializer.php
@@ -14,6 +14,7 @@ namespace FoF\Reactions\Api\Serializer;
 use Flarum\Api\Serializer\AbstractSerializer;
 use Flarum\Api\Serializer\BasicPostSerializer;
 use Flarum\Api\Serializer\BasicUserSerializer;
+use Illuminate\Support\Str;
 
 class PostReactionSerializer extends AbstractSerializer
 {
@@ -27,8 +28,14 @@ class PostReactionSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($postReaction)
     {
+        if (Str::length($postReaction->user_id) === 40) {
+            $userId = null;
+        } else {
+            $userId = $postReaction->user_id;
+        }
+        
         return [
-            'userId'     => $postReaction->user_id,
+            'userId'     => $userId,
             'postId'     => $postReaction->post_id,
             'reactionId' => $postReaction->reaction_id,
         ];

--- a/src/Api/Serializer/PostReactionSerializer.php
+++ b/src/Api/Serializer/PostReactionSerializer.php
@@ -33,7 +33,7 @@ class PostReactionSerializer extends AbstractSerializer
         } else {
             $userId = $postReaction->user_id;
         }
-        
+
         return [
             'userId'     => $userId,
             'postId'     => $postReaction->post_id,

--- a/src/Event/PostWasReacted.php
+++ b/src/Event/PostWasReacted.php
@@ -13,8 +13,8 @@ namespace FoF\Reactions\Event;
 
 use Flarum\Post\Post;
 use Flarum\User\User;
-use FoF\Reactions\PostReaction;
 use FoF\Reactions\PostAnonymousReaction;
+use FoF\Reactions\PostReaction;
 use FoF\Reactions\Reaction;
 
 class PostWasReacted
@@ -47,11 +47,11 @@ class PostWasReacted
     /**
      * PostWasReacted constructor.
      *
-     * @param Post         $post
+     * @param Post                               $post
      * @param PostReaction|PostAnonymousReaction $postReaction
-     * @param User         $user
-     * @param Reaction     $reaction
-     * @param bool         $changed
+     * @param User                               $user
+     * @param Reaction                           $reaction
+     * @param bool                               $changed
      */
     public function __construct(Post $post, $postReaction, User $user, Reaction $reaction, $changed = false)
     {

--- a/src/Event/PostWasReacted.php
+++ b/src/Event/PostWasReacted.php
@@ -14,6 +14,7 @@ namespace FoF\Reactions\Event;
 use Flarum\Post\Post;
 use Flarum\User\User;
 use FoF\Reactions\PostReaction;
+use FoF\Reactions\PostAnonymousReaction;
 use FoF\Reactions\Reaction;
 
 class PostWasReacted
@@ -24,7 +25,7 @@ class PostWasReacted
     public $post;
 
     /**
-     * @var PostReaction
+     * @var PostReaction|PostAnonymousReaction
      */
     public $postReaction;
 
@@ -47,12 +48,12 @@ class PostWasReacted
      * PostWasReacted constructor.
      *
      * @param Post         $post
-     * @param PostReaction $postReaction
+     * @param PostReaction|PostAnonymousReaction $postReaction
      * @param User         $user
      * @param Reaction     $reaction
      * @param bool         $changed
      */
-    public function __construct(Post $post, PostReaction $postReaction, User $user, Reaction $reaction, $changed = false)
+    public function __construct(Post $post, $postReaction, User $user, Reaction $reaction, $changed = false)
     {
         $this->post = $post;
         $this->postReaction = $postReaction;

--- a/src/Event/PostWasUnreacted.php
+++ b/src/Event/PostWasUnreacted.php
@@ -13,8 +13,8 @@ namespace FoF\Reactions\Event;
 
 use Flarum\Post\Post;
 use Flarum\User\User;
-use FoF\Reactions\PostReaction;
 use FoF\Reactions\PostAnonymousReaction;
+use FoF\Reactions\PostReaction;
 
 class PostWasUnreacted
 {
@@ -34,9 +34,9 @@ class PostWasUnreacted
     public $user;
 
     /**
-     * @param Post         $post
+     * @param Post                               $post
      * @param PostReaction|PostAnonymousReaction $postReaction
-     * @param User         $user
+     * @param User                               $user
      */
     public function __construct(Post $post, $postReaction, User $user)
     {

--- a/src/Event/PostWasUnreacted.php
+++ b/src/Event/PostWasUnreacted.php
@@ -14,6 +14,7 @@ namespace FoF\Reactions\Event;
 use Flarum\Post\Post;
 use Flarum\User\User;
 use FoF\Reactions\PostReaction;
+use FoF\Reactions\PostAnonymousReaction;
 
 class PostWasUnreacted
 {
@@ -23,7 +24,7 @@ class PostWasUnreacted
     public $post;
 
     /**
-     * @var PostReaction
+     * @var PostReaction|PostAnonymousReaction
      */
     public $postReaction;
 
@@ -34,10 +35,10 @@ class PostWasUnreacted
 
     /**
      * @param Post         $post
-     * @param PostReaction $postReaction
+     * @param PostReaction|PostAnonymousReaction $postReaction
      * @param User         $user
      */
-    public function __construct(Post $post, PostReaction $postReaction, User $user)
+    public function __construct(Post $post, $postReaction, User $user)
     {
         $this->post = $post;
         $this->postReaction = $postReaction;

--- a/src/Event/WillReactToPost.php
+++ b/src/Event/WillReactToPost.php
@@ -42,7 +42,7 @@ class WillReactToPost
      *
      * @param Post $post
      * @param User $user
-     * @param $reaction
+     * @param      $reaction
      * @param bool $changed
      */
     public function __construct(Post $post, User $user, Reaction $reaction, $changed = false)

--- a/src/Event/WillReactToPost.php
+++ b/src/Event/WillReactToPost.php
@@ -50,5 +50,6 @@ class WillReactToPost
         $this->post = $post;
         $this->user = $user;
         $this->reaction = $reaction;
+        $this->changed = $changed;
     }
 }

--- a/src/Listener/SaveReactionsToDatabase.php
+++ b/src/Listener/SaveReactionsToDatabase.php
@@ -153,7 +153,7 @@ class SaveReactionsToDatabase
                         $postReaction = $isGuest ? new PostAnonymousReaction() : new PostReaction();
 
                         $postReaction->post_id = $post->id;
-                        
+
                         if ($isGuest) {
                             $postReaction->guest_id = $guestId;
                         } else {
@@ -177,7 +177,7 @@ class SaveReactionsToDatabase
     }
 
     /**
-     * @param $event
+     * @param              $event
      * @param PostReaction $postReaction
      * @param Reaction     $reaction
      * @param User         $actor

--- a/src/Listener/SendNotifications.php
+++ b/src/Listener/SendNotifications.php
@@ -17,6 +17,7 @@ use Flarum\User\User;
 use FoF\Reactions\Event\PostWasReacted;
 use FoF\Reactions\Event\PostWasUnreacted;
 use FoF\Reactions\Notification\PostReactedBlueprint;
+use FoF\Reactions\PostAnonymousReaction;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class SendNotifications
@@ -35,6 +36,10 @@ class SendNotifications
      */
     public function whenPostWasReacted(PostWasReacted $event)
     {
+        if ($event->postReaction instanceof PostAnonymousReaction) {
+            return;
+        }
+
         $this->sync($event->post, $event->user, $event->reaction, [$event->post->user]);
     }
 
@@ -43,6 +48,10 @@ class SendNotifications
      */
     public function whenPostWasUnreacted(PostWasUnreacted $event)
     {
+        if ($event->postReaction instanceof PostAnonymousReaction) {
+            return;
+        }
+        
         $this->sync($event->post, $event->user, '', []);
     }
 

--- a/src/Listener/SendNotifications.php
+++ b/src/Listener/SendNotifications.php
@@ -51,7 +51,7 @@ class SendNotifications
         if ($event->postReaction instanceof PostAnonymousReaction) {
             return;
         }
-        
+
         $this->sync($event->post, $event->user, '', []);
     }
 

--- a/src/Middleware/BindRequestToContainer.php
+++ b/src/Middleware/BindRequestToContainer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FoF\Reactions\Middleware;
+
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Illuminate\Contracts\Container\Container;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+
+class BindRequestToContainer implements MiddlewareInterface
+{
+    protected $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // This is used in order to make the request available to the `SaveReactionsToDatabase` listener.
+        // TODO: Remove this once we have a better way to do this (v2.0?)
+        $this->container->instance('fof-reactions.request', $request);
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Middleware/BindRequestToContainer.php
+++ b/src/Middleware/BindRequestToContainer.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Reactions\Middleware;
 
-use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Http\Message\ResponseInterface;
 use Illuminate\Contracts\Container\Container;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 class BindRequestToContainer implements MiddlewareInterface
 {

--- a/src/PostAnonymousReaction.php
+++ b/src/PostAnonymousReaction.php
@@ -21,8 +21,8 @@ class PostAnonymousReaction extends AbstractModel
     public $timestamps = true;
 
     public $casts = [
-        'created_at' => 'datetime', 
-        'updated_at' => 'datetime'
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
     ];
 
     protected $fillable = ['post_id', 'guest_id', 'reaction_id'];

--- a/src/PostAnonymousReaction.php
+++ b/src/PostAnonymousReaction.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Reactions;
+
+use Flarum\Database\AbstractModel;
+use Flarum\Post\Post;
+
+class PostAnonymousReaction extends AbstractModel
+{
+    protected $table = 'post_anonymous_reactions';
+
+    public $timestamps = true;
+
+    public $casts = [
+        'created_at' => 'datetime', 
+        'updated_at' => 'datetime'
+    ];
+
+    protected $fillable = ['post_id', 'guest_id', 'reaction_id'];
+
+    public function reaction()
+    {
+        return $this->belongsTo(Reaction::class);
+    }
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/src/PostAttributes.php
+++ b/src/PostAttributes.php
@@ -59,7 +59,7 @@ class PostAttributes
 
         // Query for anonymous reactions if allowed
         $anonymousReactions = collect([]);
-        if ($this->settings->get('fof-reactions.allow-anonymous')) {
+        if ($this->settings->get('fof-reactions.anonymousReactions')) {
             $anonymousReactions = PostAnonymousReaction::where('post_id', $post->id)
                 ->groupBy('reaction_id')
                 ->selectRaw('reaction_id, COUNT(*) as count')

--- a/src/PostAttributes.php
+++ b/src/PostAttributes.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace FoF\Reactions;
+
+use Flarum\Api\Serializer\PostSerializer;
+use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\User;
+use Psr\Http\Message\ServerRequestInterface;
+
+class PostAttributes
+{
+    /** @var SettingsRepositoryInterface $settings */
+    protected $settings;
+
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function __invoke(PostSerializer $serializer, Post $post, array $attributes): array
+    {
+        $actor = $serializer->getActor();
+
+        $attributes['canReact'] = (bool) $actor->can('react', $post);
+
+        // Get reaction counts for the post.
+        $reactionCounts = $this->getReactionCountsForPost($post);
+
+        // Get user's reaction to the post.
+        $userReaction = $this->getActorReactionForPost($actor, $post, $serializer->getRequest());
+
+        // Add custom attributes.
+        $attributes['reactionCounts'] = $reactionCounts;
+        $attributes['userReactionIdentifier'] = $userReaction;
+
+        return $attributes;
+    }
+
+    protected function getReactionCountsForPost(Post $post): array
+    {
+        // Initialize counts array
+        $counts = [];
+
+        // Query for reactions from registered users
+        $registeredReactions = PostReaction::where('post_id', $post->id)
+            ->groupBy('reaction_id')
+            ->selectRaw('reaction_id, COUNT(*) as count')
+            ->pluck('count', 'reaction_id');
+
+        // Query for anonymous reactions if allowed
+        $anonymousReactions = collect([]);
+        if ($this->settings->get('fof-reactions.allow-anonymous')) {
+            $anonymousReactions = PostAnonymousReaction::where('post_id', $post->id)
+                ->groupBy('reaction_id')
+                ->selectRaw('reaction_id, COUNT(*) as count')
+                ->pluck('count', 'reaction_id');
+        }
+
+        // Merge the registered and anonymous reactions
+        $reactions = Reaction::all();
+        foreach ($reactions as $reaction) {
+            $counts[$reaction->id] = $registeredReactions->get($reaction->id, 0) + $anonymousReactions->get($reaction->id, 0);
+        }
+
+        return $counts;
+    }
+
+    protected function getActorReactionForPost(User $actor, Post $post, ServerRequestInterface $request): ?int
+    {
+        if ($actor->isGuest()) {
+            return PostAnonymousReaction::where('post_id', $post->id)
+                ->where('guest_id', $request->getAttribute('session')->getId())
+                ->value('reaction_id');
+        }
+
+        return PostReaction::where('post_id', $post->id)
+            ->where('user_id', $actor->id)
+            ->value('reaction_id');
+    }
+}

--- a/src/PostAttributes.php
+++ b/src/PostAttributes.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Reactions;
 
 use Flarum\Api\Serializer\PostSerializer;
@@ -10,7 +19,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class PostAttributes
 {
-    /** @var SettingsRepositoryInterface $settings */
+    /** @var SettingsRepositoryInterface */
     protected $settings;
 
     public function __construct(SettingsRepositoryInterface $settings)

--- a/src/Reaction.php
+++ b/src/Reaction.php
@@ -29,8 +29,8 @@ class Reaction extends AbstractModel
     /**
      * Create a reaction.
      *
-     * @param $identifier
-     * @param $type
+     * @param      $identifier
+     * @param      $type
      * @param bool $enabled
      *
      * @return static


### PR DESCRIPTION
This pull request introduces a new feature that allows guest/anonymous users to react to posts. This feature can be toggled on or off via an admin setting. The default is off.

Here is a summary of the changes:

1. **Backend**: Logic has been added to handle reactions from anonymous users. This includes creating, deleting, and fetching reactions. The data structure has been updated to include anonymous reactions in the reaction counts.

2. **Frontend**: The components that display reactions have been updated to support anonymous users. This includes the reactions list on each post, the modal that shows all reactions to a post, and the action to add a reaction.

This feature enhances the interactivity of forums by allowing guest users to react to posts. It also provides forum admins with more control over the level of interaction they want to enable on their forums.

Admin:
![image](https://github.com/FriendsOfFlarum/reactions/assets/16573496/b4a1c42b-41db-460d-9b7a-1cd0721c0a58)

Forum:
![image](https://github.com/FriendsOfFlarum/reactions/assets/16573496/643fd4db-3507-4bdb-876e-9a4f9b7a310a)
