### PR TITLE
Reactions list modal improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 [*.md]
-indent_size = 2
 trim_trailing_whitespace = false
+[*.{.md,js}]
+indent_size = 2

--- a/extend.php
+++ b/extend.php
@@ -37,7 +37,8 @@ return [
 
     (new Extend\Routes('api'))
         ->get('/posts/{id}/reactions', 'post.reactions.index', Controller\ListPostReactionsController::class)
-        ->delete('/posts/{id}/reactions/{reactionId}', 'post.reactions.delete', Controller\DeletePostReactionController::class)
+        ->delete('/posts/{id}/reactions/specific/{postReactionId}', 'post.reactions.specific.delete', Controller\DeletePostReactionController::class)
+        ->delete('/posts/{id}/reactions/type/{reactionId}', 'post.reactions.type.delete', Controller\DeletePostReactionController::class)
         ->get('/reactions', 'reactions.index', Controller\ListReactionsController::class)
         ->post('/reactions', 'reactions.create', Controller\CreateReactionController::class)
         ->patch('/reactions/{id}', 'reactions.update', Controller\UpdateReactionController::class)

--- a/extend.php
+++ b/extend.php
@@ -37,6 +37,7 @@ return [
 
     (new Extend\Routes('api'))
         ->get('/posts/{id}/reactions', 'post.reactions.index', Controller\ListPostReactionsController::class)
+        ->delete('/posts/{id}/reactions/{reactionId}', 'post.reactions.delete', Controller\DeletePostReactionController::class)
         ->get('/reactions', 'reactions.index', Controller\ListReactionsController::class)
         ->post('/reactions', 'reactions.create', Controller\CreateReactionController::class)
         ->patch('/reactions/{id}', 'reactions.update', Controller\UpdateReactionController::class)

--- a/js/src/@types/shims.d.ts
+++ b/js/src/@types/shims.d.ts
@@ -4,7 +4,7 @@ import Reaction from '../common/models/Reaction';
 declare module 'flarum/common/models/Post' {
   export default interface Post {
     reactionCounts(): Record<string, number>;
-    userReaction(): PostReaction | null;
+    userReaction(): number | undefined;
 
     canReact(): boolean;
     canDeletePostReactions(): boolean;

--- a/js/src/@types/shims.d.ts
+++ b/js/src/@types/shims.d.ts
@@ -1,0 +1,24 @@
+import PostReaction from '../forum/models/PostReaction';
+import Reaction from '../common/models/Reaction';
+
+declare module 'flarum/common/models/Post' {
+  export default interface Post {
+    reactionCounts(): Record<string, number>;
+    userReaction(): PostReaction | null;
+
+    canReact(): boolean;
+    canDeletePostReactions(): boolean;
+  }
+}
+
+declare module 'flarum/common/models/Discussion' {
+  export default interface Discussion {
+    canSeeReactions(): boolean;
+  }
+}
+
+declare module 'flarum/forum/models/Forum' {
+  export default interface Forum {
+    reactions(): Reaction[];
+  }
+}

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -38,7 +38,7 @@ app.initializers.add('fof/reactions', () => {
       {
         icon: 'fas fa-trash',
         label: app.translator.trans('fof-reactions.admin.permissions.delete_post_reactions_label'),
-        permission: 'discussion.deletePostReactions',
+        permission: 'discussion.deleteReactionsPosts',
       },
       'moderate'
     )

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -34,5 +34,13 @@ app.initializers.add('fof/reactions', () => {
       },
       'view'
     )
+    .registerPermission(
+      {
+        icon: 'fas fa-trash',
+        label: app.translator.trans('fof-reactions.admin.permissions.delete_post_reactions_label'),
+        permission: 'discussion.deletePostReactions',
+      },
+      'moderate'
+    )
     .registerPage(SettingsPage);
 });

--- a/js/src/common/components/ReactionComponent.js
+++ b/js/src/common/components/ReactionComponent.js
@@ -19,9 +19,9 @@ export default class ReactionComponent extends Component {
     if (reaction.type() === 'emoji') {
       const { url } = emoji(reaction.identifier());
 
-      return <img className={className} src={url} loading="lazy" draggable="false" alt={display} {...attrs} />;
+      return <img className={classList(className, 'emoji')} src={url} loading="lazy" draggable="false" alt={display} {...attrs} />;
     } else {
-      return <i className={classList(className, reaction.identifier())} aria-hidden {...attrs} />;
+      return <i className={classList(className, reaction.identifier(), 'icon')} aria-hidden {...attrs} />;
     }
   }
 }

--- a/js/src/forum/components/PostReactAction.js
+++ b/js/src/forum/components/PostReactAction.js
@@ -77,9 +77,7 @@ export default class PostReactAction extends Component {
 
             return Button.component(
               {
-                className: `Button Button--flat Button-emoji-parent ${
-                  this.post.userReaction() && this.post.userReaction() == reaction.id() && 'active'
-                }`,
+                className: `Button Button--flat Button-emoji-parent ${this.post.userReaction() == reaction.id() && 'active'}`,
                 onclick: canReact ? this.react.bind(this, reaction) : '',
                 'data-reaction': reaction.identifier(),
                 disabled: !canReact,

--- a/js/src/forum/components/PostReactAction.js
+++ b/js/src/forum/components/PostReactAction.js
@@ -63,6 +63,8 @@ export default class PostReactAction extends Component {
     const reactionCounts = this.post.reactionCounts();
     const canReact = this.post.canReact();
 
+    const hasReacted = this.post.userReaction() && reactionCounts[this.post.userReaction()] > 0;
+
     return (
       <div style="margin-right: 7px" className="Reactions">
         <div className="Reactions--reactions">
@@ -90,7 +92,7 @@ export default class PostReactAction extends Component {
           })}
         </div>
 
-        {(!Object.keys(this.loading).length || this.loading[null]) && !this.post.userReaction() && canReact && (
+        {(!Object.keys(this.loading).length || this.loading[null]) && !hasReacted && canReact && (
           <div className="Reactions--react">
             {this.reactButton()}
 

--- a/js/src/forum/components/ReactionsModal.tsx
+++ b/js/src/forum/components/ReactionsModal.tsx
@@ -12,6 +12,7 @@ import Post from 'flarum/common/models/Post';
 import { ApiResponsePlural } from 'flarum/common/Store';
 import User from 'flarum/common/models/User';
 import Reaction from '../../common/models/Reaction';
+import Button from 'flarum/common/components/Button';
 
 interface ReactionsModalAttrs extends IInternalModalAttrs {
   post: Post;
@@ -19,13 +20,14 @@ interface ReactionsModalAttrs extends IInternalModalAttrs {
 
 interface ReactionGroup {
   reaction: Reaction;
-  users: User[];
+  users: Record<string, User>; // map the post reaction id to the user
   anonymousCount: number;
 }
 
 export default class ReactionsModal extends Modal<ReactionsModalAttrs> {
   reactions: ReactionGroup[] = [];
   loading: boolean = false;
+  deleting: Record<string, boolean> = {};
 
   className() {
     return 'ReactionsModal Modal--small';
@@ -58,7 +60,13 @@ export default class ReactionsModal extends Modal<ReactionsModalAttrs> {
     );
   }
 
-  buildReactionSection(reaction: Reaction, users: User[], anonymousCount: number): Mithril.Children {
+  buildReactionSection(reaction: Reaction, users: Record<string, User>, anonymousCount: number): Mithril.Children {
+    const post = this.attrs.post;
+
+    // The user can delete the reaction if they can delete reactions on the post, or
+    // if they can react (i.e. modify their reaction) and it's their own reaction
+    const canDeleteReaction = (user: User) => post.canDeletePostReactions() || (post.canReact() && user === app.session.user);
+
     return (
       <div className="ReactionsModal-group">
         <legend>
@@ -68,12 +76,20 @@ export default class ReactionsModal extends Modal<ReactionsModalAttrs> {
 
         <hr className="ReactionsModal-delimiter" />
 
-        {users.map((user: User) => (
-          <li key={user.id()}>
+        {Object.entries(users).map(([postReactionId, user]: [string, User], index: number) => (
+          <li key={user.id()} data-post-reaction-id={postReactionId} data-user-id={user.id()}>
             <Link className="ReactionsModal-user" href={app.route.user(user)}>
               {avatar(user, { loading: 'lazy' })}
               {username(user)}
             </Link>
+            {canDeleteReaction(user) && (
+              <Button
+                icon="fas fa-minus-circle"
+                className="Button Button--icon Button--link"
+                loading={this.deleting[postReactionId]}
+                onclick={this.deletePostReaction.bind(this, postReactionId, reaction.id()!)}
+              />
+            )}
           </li>
         ))}
 
@@ -97,7 +113,7 @@ export default class ReactionsModal extends Modal<ReactionsModalAttrs> {
         continue;
       }
 
-      const users: User[] = [];
+      const users: Record<string, User> = {};
       let anonymousCount = 0;
 
       for (let reactionInstance of groupedReactions[reactionId]) {
@@ -109,7 +125,7 @@ export default class ReactionsModal extends Modal<ReactionsModalAttrs> {
           const user = app.store.getById<User>('users', userId);
           if (user) {
             // Check for null user
-            users.push(user);
+            users[reactionInstance.id()!] = user;
           }
         }
       }
@@ -119,6 +135,36 @@ export default class ReactionsModal extends Modal<ReactionsModalAttrs> {
 
     this.reactions = reactions;
     this.loading = false;
+
+    m.redraw();
+  }
+
+  async deletePostReaction(postReactionId: string, reactionId: string): Promise<void> {
+    if (!postReactionId) return;
+
+    this.deleting[postReactionId] = true;
+
+    await app.request({
+      method: 'DELETE',
+      url: `${app.forum.attribute('apiUrl')}/posts/${this.attrs.post.id()}/reactions/${postReactionId}`,
+    });
+
+    // Filter out the deleted reaction
+    const reaction = this.reactions.find((reaction) => reaction.reaction.id() === reactionId);
+    const postReaction = app.store.getById('post_reactions', postReactionId);
+
+    if (reaction) {
+      delete reaction.users[postReactionId];
+
+      // Remove reaction group if there are no more reactions of this type
+      if (!Object.keys(reaction.users).length && !reaction.anonymousCount) {
+        this.reactions = this.reactions.filter((r) => r.reaction.id() !== reactionId);
+      }
+    }
+
+    if (postReaction) app.store.remove(postReaction);
+
+    delete this.deleting[postReactionId];
 
     m.redraw();
   }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -27,6 +27,7 @@ app.initializers.add('fof/reactions', () => {
   app.notificationComponents.postReacted = PostReactedNotification;
 
   Post.prototype.canReact = Model.attribute('canReact');
+  Post.prototype.canDeletePostReactions = Model.attribute('canDeletePostReactions');
   Post.prototype.reactionCounts = Model.attribute('reactionCounts');
   Post.prototype.userReaction = Model.attribute('userReaction');
 

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -29,7 +29,7 @@ app.initializers.add('fof/reactions', () => {
   Post.prototype.canReact = Model.attribute('canReact');
   Post.prototype.canDeletePostReactions = Model.attribute('canDeletePostReactions');
   Post.prototype.reactionCounts = Model.attribute('reactionCounts');
-  Post.prototype.userReaction = Model.attribute('userReaction');
+  Post.prototype.userReaction = Model.attribute('userReactionIdentifier');
 
   Forum.prototype.reactions = Model.hasMany('reactions');
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -137,6 +137,18 @@
     .ReactionsModal-group {
         margin-bottom: 40px;
 
+        legend {
+            display: flex;
+
+            label {
+                flex: 1;
+            }
+
+            .Button {
+                padding: 2px 0;
+            }
+        }
+
         .ReactionsModal-reaction {
             .emoji {
                 height: 24px;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -126,6 +126,14 @@
         }
     }
 
+    li {
+        display: flex;
+
+        .ReactionsModal-user {
+            flex: 1;
+        }
+    }
+
     .ReactionsModal-group {
         margin-bottom: 40px;
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -9,6 +9,7 @@ fof-reactions:
     modal:
         title: Reactions
         anonymous_count: "{count, plural, one {# anonymous user} other {# anonymous users}}"
+        no_reactions: No reactions yet
     mod_item: View Reactions
     react_button_label: React
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -16,12 +16,13 @@ fof-reactions:
     permissions:
         react_posts_label: React to posts
         see_reactions_label: See who reacted on posts
+        delete_post_reactions_label: Delete reactions on posts
 
     page:
       cdn:
         title: CDN
         help: |
-          By default, we serve the reaction assets from Cloudflare's CDN. You also have the option to specify any other CDN address 
+          By default, we serve the reaction assets from Cloudflare's CDN. You also have the option to specify any other CDN address
           as required. <code>[codepoint]</code> will be substituted with the codepoint of the emoji.
 
           For example, to switch to Noto Emoji via jsdelivr, you would enter <code>https://cdn.jsdelivr.net/gh/googlefonts/noto-emoji@v2.040/svg/emoji_u[codepoint].svg</code>. This field must NEVER be left empty.

--- a/src/Api/Controller/DeletePostReactionController.php
+++ b/src/Api/Controller/DeletePostReactionController.php
@@ -14,6 +14,8 @@ namespace FoF\Reactions\Api\Controller;
 use Flarum\Api\Controller\AbstractDeleteController;
 use Flarum\Http\RequestUtil;
 use Flarum\Post\Post;
+use Flarum\User\Exception\PermissionDeniedException;
+use FoF\Reactions\PostAnonymousReaction;
 use FoF\Reactions\PostReaction;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
@@ -21,23 +23,41 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class DeletePostReactionController extends AbstractDeleteController
 {
-    protected function delete(ServerRequestInterface $request)
+    /**
+     * @throws PermissionDeniedException
+     */
+    protected function delete(ServerRequestInterface $request): EmptyResponse
     {
         $actor = RequestUtil::getActor($request);
-        $postId = Arr::get($request->getQueryParams(), 'id');
-        $postReactionId = Arr::get($request->getQueryParams(), 'reactionId');
+        $params = $request->getQueryParams();
+
+        $postId = Arr::get($params, 'id');
+        $postReactionId = Arr::get($params, 'postReactionId');
+        $reactionId = Arr::get($params, 'reactionId');
 
         $post = Post::whereVisibleTo($actor)->findOrFail($postId);
-        $reaction = PostReaction::query()->where('post_id', $postId)->where('id', $postReactionId)->firstOrFail();
 
         $actor->assertCan('react', $post);
 
-        // If the post is not the actor's, they must have permission to delete reactions
-        if ($reaction->user_id !== $actor->id) {
+        if ($reactionId) {
+            // Delete all post_reactions of a specific type (i.e. `reaction_id`)
             $actor->assertCan('deletePostReactions', $post);
+
+            PostReaction::query()->where('post_id', $postId)->where('reaction_id', $reactionId)->delete();
+            PostAnonymousReaction::query()->where('post_id', $postId)->where('reaction_id', $reactionId)->delete();
+        } else if ($postReactionId) {
+            // Delete a specific post_reaction for the post
+            $reaction = PostReaction::query()->where('post_id', $postId)->where('id', $postReactionId)->firstOrFail();
+
+            // If the post is not the actor's, they must have permission to delete reactions
+            if ($reaction->user_id !== $actor->id) {
+                $actor->assertCan('deletePostReactions', $post);
+            }
+
+            $reaction->delete();
         }
 
-        $reaction->delete();
+        // TODO should this send pusher updates? would need new type for non-specific, otherwise could spam pusher events
 
         return new EmptyResponse(204);
     }

--- a/src/Api/Controller/DeletePostReactionController.php
+++ b/src/Api/Controller/DeletePostReactionController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FoF\Reactions\Api\Controller;
+
+use Flarum\Api\Controller\AbstractDeleteController;
+use Flarum\Http\RequestUtil;
+use Flarum\Post\Post;
+use FoF\Reactions\PostReaction;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Psr\Http\Message\ServerRequestInterface;
+
+class DeletePostReactionController extends AbstractDeleteController
+{
+
+    protected function delete(ServerRequestInterface $request)
+    {
+        $actor = RequestUtil::getActor($request);
+        $postId = Arr::get($request->getQueryParams(), 'id');
+        $postReactionId = Arr::get($request->getQueryParams(), 'reactionId');
+
+        $post = Post::whereVisibleTo($actor)->findOrFail($postId);
+        $reaction = PostReaction::query()->where('post_id', $postId)->where('id', $postReactionId)->firstOrFail();
+
+        $actor->assertCan('react', $post);
+
+        // If the post is not the actor's, they must have permission to delete reactions
+        if ($reaction->user_id !== $actor->id) {
+            $actor->assertCan('deletePostReactions', $post);
+        }
+
+        $reaction->delete();
+
+        return new EmptyResponse(204);
+    }
+}

--- a/src/Api/Controller/DeletePostReactionController.php
+++ b/src/Api/Controller/DeletePostReactionController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Reactions\Api\Controller;
 
 use Flarum\Api\Controller\AbstractDeleteController;
@@ -12,7 +21,6 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class DeletePostReactionController extends AbstractDeleteController
 {
-
     protected function delete(ServerRequestInterface $request)
     {
         $actor = RequestUtil::getActor($request);

--- a/src/Api/Controller/DeletePostReactionController.php
+++ b/src/Api/Controller/DeletePostReactionController.php
@@ -37,21 +37,24 @@ class DeletePostReactionController extends AbstractDeleteController
 
         $post = Post::whereVisibleTo($actor)->findOrFail($postId);
 
-        $actor->assertCan('react', $post);
-
         if ($reactionId) {
             // Delete all post_reactions of a specific type (i.e. `reaction_id`)
-            $actor->assertCan('deletePostReactions', $post);
+            $actor->assertCan('deleteReactions', $post);
 
             PostReaction::query()->where('post_id', $postId)->where('reaction_id', $reactionId)->delete();
             PostAnonymousReaction::query()->where('post_id', $postId)->where('reaction_id', $reactionId)->delete();
         } elseif ($postReactionId) {
             // Delete a specific post_reaction for the post
+            /**
+             * @var PostReaction $reaction
+             */
             $reaction = PostReaction::query()->where('post_id', $postId)->where('id', $postReactionId)->firstOrFail();
 
             // If the post is not the actor's, they must have permission to delete reactions
-            if ($reaction->user_id !== $actor->id) {
-                $actor->assertCan('deletePostReactions', $post);
+            if ($reaction->user_id != $actor->id) {
+                $actor->assertCan('deleteReactions', $post);
+            } else {
+                $actor->assertCan('react', $post);
             }
 
             $reaction->delete();

--- a/src/Api/Controller/DeletePostReactionController.php
+++ b/src/Api/Controller/DeletePostReactionController.php
@@ -45,7 +45,7 @@ class DeletePostReactionController extends AbstractDeleteController
 
             PostReaction::query()->where('post_id', $postId)->where('reaction_id', $reactionId)->delete();
             PostAnonymousReaction::query()->where('post_id', $postId)->where('reaction_id', $reactionId)->delete();
-        } else if ($postReactionId) {
+        } elseif ($postReactionId) {
             // Delete a specific post_reaction for the post
             $reaction = PostReaction::query()->where('post_id', $postId)->where('id', $postReactionId)->firstOrFail();
 

--- a/src/PostAttributes.php
+++ b/src/PostAttributes.php
@@ -32,7 +32,7 @@ class PostAttributes
         $actor = $serializer->getActor();
 
         $attributes['canReact'] = (bool) $actor->can('react', $post);
-        $attributes['canDeletePostReactions'] = (bool) $actor->can('deletePostReactions', $post);
+        $attributes['canDeletePostReactions'] = (bool) $actor->can('deleteReactions', $post);
 
         // Get reaction counts for the post.
         $reactionCounts = $this->getReactionCountsForPost($post);

--- a/src/PostAttributes.php
+++ b/src/PostAttributes.php
@@ -32,6 +32,7 @@ class PostAttributes
         $actor = $serializer->getActor();
 
         $attributes['canReact'] = (bool) $actor->can('react', $post);
+        $attributes['canDeletePostReactions'] = (bool) $actor->can('deletePostReactions', $post);
 
         // Get reaction counts for the post.
         $reactionCounts = $this->getReactionCountsForPost($post);

--- a/tests/integration/api/ReactTest.php
+++ b/tests/integration/api/ReactTest.php
@@ -16,10 +16,8 @@ use Flarum\Group\Group;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
-use Flarum\User\User;
 use FoF\Reactions\PostAnonymousReaction;
 use FoF\Reactions\PostReaction;
-use FoF\Reactions\Reaction;
 use Psr\Http\Message\ResponseInterface;
 
 class ReactTest extends TestCase
@@ -301,7 +299,8 @@ class ReactTest extends TestCase
         }
     }
 
-    public function deleteSpecificPostReactionUsersData() {
+    public function deleteSpecificPostReactionUsersData()
+    {
         return [
             // [$reactionAs, $authAs, $message, $statusCode]
             [3, 1, 'Admin can delete any post reaction', 204],


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Allow deleting individual post reactions in post reactions list
- Fix emojis being too large in modal
- Fix showing if user has voted on the post already

**Reviewers should focus on:**
This logic does not work for anonymous votes. It'd make sense to allow to delete an entire reaction type (I really hate the terminology being the same 😮‍💨), but I wasn't sure what API URL to use for that. As it stands already, it's not clear whether the endpoint is for a `post_reaction` or `reaction` ID... and since `/posts/{id}/reactions` returns `post_reactions`, I don't know whether the mismatch can be avoided at all.

**Screenshot**
![image](https://github.com/FriendsOfFlarum/reactions/assets/6401250/88ac4c76-4805-4322-9019-61e50f720a45)
![image](https://github.com/FriendsOfFlarum/reactions/assets/6401250/79f80f9c-e607-4530-a27a-e4b61204cd5f) ![image](https://github.com/FriendsOfFlarum/reactions/assets/6401250/6082f8b3-564f-449d-97e6-0b4ba94f6f45)


**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
  - I haven't looked at tests at all. I know I could make them, but didn't feel like putting the work to learn & have the setup ready rn
