### PR TITLE
Fix creation of dynamic property in core/flarum DispatchEventsTrait

### DIFF
--- a/src/Event/WillReactToPost.php
+++ b/src/Event/WillReactToPost.php
@@ -25,7 +25,7 @@ class WillReactToPost
     /**
      * @var User
      */
-    public $user;
+    public $actor;
 
     /**
      * @var Reaction
@@ -48,7 +48,7 @@ class WillReactToPost
     public function __construct(Post $post, User $user, Reaction $reaction, $changed = false)
     {
         $this->post = $post;
-        $this->user = $user;
+        $this->actor = $user;
         $this->reaction = $reaction;
         $this->changed = $changed;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #84 #85**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Just renamed `$user` field of this event to `$actor`, because [core/flarum DispatchEventsTrait](https://github.com/flarum/framework/blob/5820a16a964765174a102a00a5c651a6a898f822/framework/core/src/Foundation/DispatchEventsTrait.php#L28) trying to write `->actor` field, which is not exists and php8.1+ fails because of deprecation error

- Event/WillReactToPost.php

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
seems to `WillReactToPost::$actor` is not reading or writing outside of the class.  
maybe we should prefer getter methods instead of direct field access?

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
dont have any

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

- [x] Tested it right on production by applying this path directly to vendor dir and liked a random post :3

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
