### PR TITLE
perf: batch-load reaction counts for posts embedded in discussion endpoints

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -97,7 +97,9 @@ return [
         ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
             return $endpoint->beforeSerialization(function (Context $context, array $results) {
                 $loader = resolve(LoadReactionCounts::class);
-                $posts = Collection::make($results['models'])
+                /** @var Collection<int, Discussion> $discussions */
+                $discussions = Collection::make($results['models']);
+                $posts = $discussions
                     ->map(fn (Discussion $d) => $d->firstPost)
                     ->filter()
                     ->values();
@@ -109,7 +111,8 @@ return [
         ->endpoint(Endpoint\Show::class, function (Endpoint\Show $endpoint) {
             return $endpoint->beforeSerialization(function (Context $context, object $discussion) {
                 $loader = resolve(LoadReactionCounts::class);
-                $posts = Collection::make(array_filter([$discussion->firstPost, $discussion->lastPost]));
+                /** @var Discussion $discussion */
+                $posts = Collection::make(array_values(array_filter([$discussion->firstPost, $discussion->lastPost])));
                 if ($posts->isNotEmpty()) {
                     $loader->forPosts($posts, $context->getActor(), $context->request);
                 }

--- a/extend.php
+++ b/extend.php
@@ -93,7 +93,28 @@ return [
         ->fields(fn (): array => [
             Schema\Boolean::make('canSeeReactions')
                 ->get(fn (Discussion $discussion, Context $context) => $context->getActor()->can('canSeeReactions', $discussion)),
-        ]),
+        ])
+        ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
+            return $endpoint->beforeSerialization(function (Context $context, array $results) {
+                $loader = resolve(LoadReactionCounts::class);
+                $posts = Collection::make($results['models'])
+                    ->map(fn (Discussion $d) => $d->firstPost)
+                    ->filter()
+                    ->values();
+                if ($posts->isNotEmpty()) {
+                    $loader->forPosts($posts, $context->getActor(), $context->request);
+                }
+            });
+        })
+        ->endpoint(Endpoint\Show::class, function (Endpoint\Show $endpoint) {
+            return $endpoint->beforeSerialization(function (Context $context, object $discussion) {
+                $loader = resolve(LoadReactionCounts::class);
+                $posts = Collection::make(array_filter([$discussion->firstPost, $discussion->lastPost]));
+                if ($posts->isNotEmpty()) {
+                    $loader->forPosts($posts, $context->getActor(), $context->request);
+                }
+            });
+        }),
 
     (new Extend\SearchDriver(DatabaseSearchDriver::class))
         ->addSearcher(PostReaction::class, PostReactionSearcher::class)

--- a/extend.php
+++ b/extend.php
@@ -97,9 +97,9 @@ return [
         ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
             return $endpoint->beforeSerialization(function (Context $context, array $results) {
                 $loader = resolve(LoadReactionCounts::class);
-                /** @var Collection<int, Discussion> $discussions */
-                $discussions = Collection::make($results['models']);
-                $posts = $discussions
+                /** @var array<int, Discussion> $models */
+                $models = $results['models'];
+                $posts = Collection::make($models)
                     ->map(fn (Discussion $d) => $d->firstPost)
                     ->filter()
                     ->values();


### PR DESCRIPTION
## Problem

When the reactions extension is active, loading the discussion list triggered 3 extra queries **per discussion** — one for reaction counts, one for the actor's reaction, and one for all reaction types. With 20 discussions on a page, that's 60 additional queries.

The existing `beforeSerialization` hook on `PostResource::Index` correctly batches these queries when posts are loaded directly (e.g. when opening a discussion). However, it does not fire when posts are embedded as `firstPost`/`lastPost` within discussion responses — the `DiscussionResource::Index` and `DiscussionResource::Show` endpoints have no equivalent hook.

## Solution

Add `beforeSerialization` hooks on `DiscussionResource::Index` and `DiscussionResource::Show` that collect the embedded `firstPost`/`lastPost` models and pass them all to `LoadReactionCounts::forPosts()` in a single batch before serialization begins.

- **Index**: collects `firstPost` from all discussions in the result set — 3 queries total regardless of page size
- **Show**: collects `firstPost` and `lastPost` from the single discussion — 3 queries total

## Changes

- `extend.php`: add `beforeSerialization` on `DiscussionResource::Index` and `DiscussionResource::Show`

Relates to flarum/framework#4502