### PR TITLE
[2.x] fix: accept base Collection in LoadReactionCounts::forPosts

### DIFF
--- a/src/LoadReactionCounts.php
+++ b/src/LoadReactionCounts.php
@@ -14,7 +14,7 @@ namespace FoF\Reactions;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use Psr\Http\Message\ServerRequestInterface;
 
 class LoadReactionCounts


### PR DESCRIPTION
Fixes a TypeError thrown on `GET /api/discussions` (load more) introduced by the N+1 batch-loading changes.

`extend.php` builds the posts collection via `Collection::make()`, which returns an `Illuminate\Support\Collection`. `forPosts()` was typed to `Illuminate\Database\Eloquent\Collection`, causing a fatal type error. Widening the type hint to the base `Collection` resolves this.