### PR TITLE
[2.x] fix: ensure event dispatching only occurs for existing post reactions

### DIFF
--- a/src/PostResourceFields.php
+++ b/src/PostResourceFields.php
@@ -163,6 +163,9 @@ class PostResourceFields
             } else {
                 $guestId = $context->request->getAttribute('session')?->getId();
 
+                /**
+                 * @var PostReaction|PostAnonymousReaction|null $postReaction
+                 */
                 if ($actor->isGuest()) {
                     $postReaction = PostAnonymousReaction::where([['guest_id', $guestId], ['post_id', $post->id]])->first();
                 } else {
@@ -180,16 +183,15 @@ class PostResourceFields
 
                         $postReaction->reaction_id = null;
                         $postReaction->save();
-                    }
 
-                    $this->events->dispatch(new PostWasUnreacted($post, $postReaction, $actor));
+                        // Only dispatch event if a post reaction actually existed (anonymous or not).
+                        // We can treat this as a no-op since the end result is the same as if a reaction existed and had been removed.
+                        $this->events->dispatch(new PostWasUnreacted($post, $postReaction, $actor));
+                    }
                 } else {
                     $this->validateReaction($reaction, $reactionId);
 
-                    if ($postReaction) {
-                        $postReaction->reaction_id = $reaction->id;
-                        $postReaction->save();
-                    } else {
+                    if (!$postReaction) {
                         $isGuest = $actor->isGuest();
                         $postReaction = $isGuest ? new PostAnonymousReaction() : new PostReaction();
 
@@ -200,11 +202,10 @@ class PostResourceFields
                         } else {
                             $postReaction->user_id = $actor->id;
                         }
-
-                        $postReaction->reaction_id = $reaction->id;
-
-                        $postReaction->save();
                     }
+
+                    $postReaction->reaction_id = $reaction->id;
+                    $postReaction->save();
 
                     // We'll maintain current behaviour and only push to Pusher if the reaction is not anonymous
                     if ($postReaction instanceof PostReaction) {

--- a/src/PostResourceFields.php
+++ b/src/PostResourceFields.php
@@ -163,12 +163,11 @@ class PostResourceFields
             } else {
                 $guestId = $context->request->getAttribute('session')?->getId();
 
-                /**
-                 * @var PostReaction|PostAnonymousReaction|null $postReaction
-                 */
                 if ($actor->isGuest()) {
+                    /** @var PostAnonymousReaction|null $postReaction */
                     $postReaction = PostAnonymousReaction::where([['guest_id', $guestId], ['post_id', $post->id]])->first();
                 } else {
+                    /** @var PostReaction|Null $postReaction */
                     $postReaction = PostReaction::where([['user_id', $actor->id], ['post_id', $post->id]])->first();
                 }
 

--- a/src/PostResourceFields.php
+++ b/src/PostResourceFields.php
@@ -167,7 +167,7 @@ class PostResourceFields
                     /** @var PostAnonymousReaction|null $postReaction */
                     $postReaction = PostAnonymousReaction::where([['guest_id', $guestId], ['post_id', $post->id]])->first();
                 } else {
-                    /** @var PostReaction|Null $postReaction */
+                    /** @var PostReaction|null $postReaction */
                     $postReaction = PostReaction::where([['user_id', $actor->id], ['post_id', $post->id]])->first();
                 }
 


### PR DESCRIPTION

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Only fire PostWasUnreacted if a reaction was actually removed.

This resolves a 500 caused by the PostWasUnreacted constructor receiving null instead of a valid post reaction. If "unreacting" didn't actually take place (safe operation to ignore if not needed), then we shouldn't fire said event.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
