### PR TITLE
[2.x] Add tests for down migrations and fix foreing key constraint on uninstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ bower_components
 .floo*
 composer.lock
 .phpunit.result.cache
+.phpunit.cache
 .aider*

--- a/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
+++ b/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
@@ -33,7 +33,7 @@ return [
         $schema->table('post_reactions', function (Blueprint $table) use ($schema) {
             // Recreate single-column foreign-key index (post_id foreign index) that was automatically dropped by DB when
             // the multi-column indexes were created. Otherwise, we hit a FK constraint error.
-            if (! $schema->hasIndex('post_reactions', $foreignIndex = 'post_reactions_post_id_foreign')) {
+            if (!$schema->hasIndex('post_reactions', $foreignIndex = 'post_reactions_post_id_foreign')) {
                 $table->index(['post_id'], $foreignIndex);
             }
 
@@ -43,7 +43,7 @@ return [
 
         $schema->table('post_anonymous_reactions', function (Blueprint $table) use ($schema) {
             // Same as above, but for anonymous reactions.
-            if (! $schema->hasIndex('post_anonymous_reactions', $foreignIndex = 'post_anonymous_reactions_post_id_foreign')) {
+            if (!$schema->hasIndex('post_anonymous_reactions', $foreignIndex = 'post_anonymous_reactions_post_id_foreign')) {
                 $table->index(['post_id'], $foreignIndex);
             }
 

--- a/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
+++ b/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
@@ -30,25 +30,36 @@ return [
     },
 
     'down' => static function (Builder $schema) {
-        $schema->table('post_reactions', function (Blueprint $table) use ($schema) {
+        $dropIndexIfExists = static function (Blueprint $table, array $indices, string $indexName) {
+            if (in_array($indexName, $indices, true)) {
+                $table->dropIndex($indexName);
+            }
+        };
+
+        $schema->table('post_reactions', function (Blueprint $table) use ($dropIndexIfExists, $schema) {
+            $indices = $schema->getIndexListing('post_reactions');
+
             // Recreate single-column foreign-key index (post_id foreign index) that was automatically dropped by DB when
             // the multi-column indexes were created. Otherwise, we hit a FK constraint error.
-            if (!$schema->hasIndex('post_reactions', $foreignIndex = 'post_reactions_post_id_foreign')) {
-                $table->index(['post_id'], $foreignIndex);
+            if (!in_array($foreignIndex = 'post_reactions_post_id_foreign', $indices)) {
+                $table->index(['post_id'], 'post_reactions_post_id_foreign');
             }
 
-            $table->dropIndex('post_reactions_post_id_user_id_index');
-            $table->dropIndex('post_reactions_post_id_reaction_id_index');
+            // In case errors occurred, only drop indices if they exist to avoid "index not found" errors.
+            $dropIndexIfExists($table, $indices, 'post_reactions_post_id_user_id_index');
+            $dropIndexIfExists($table, $indices, 'post_reactions_post_id_reaction_id_index');
         });
 
-        $schema->table('post_anonymous_reactions', function (Blueprint $table) use ($schema) {
+        $schema->table('post_anonymous_reactions', function (Blueprint $table) use ($dropIndexIfExists, $schema) {
+            $indices = $schema->getIndexListing('post_anonymous_reactions');
+
             // Same as above, but for anonymous reactions.
-            if (!$schema->hasIndex('post_anonymous_reactions', $foreignIndex = 'post_anonymous_reactions_post_id_foreign')) {
+            if (!in_array($foreignIndex = 'post_anonymous_reactions_post_id_foreign', $indices, true)) {
                 $table->index(['post_id'], $foreignIndex);
             }
 
-            $table->dropIndex('post_anonymous_reactions_post_id_guest_id_index');
-            $table->dropIndex('post_anonymous_reactions_post_id_reaction_id_index');
+            $dropIndexIfExists($table, $indices, 'post_anonymous_reactions_post_id_guest_id_index');
+            $dropIndexIfExists($table, $indices, 'post_anonymous_reactions_post_id_reaction_id_index');
         });
     },
 ];

--- a/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
+++ b/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
-    'up' => function (Builder $schema) {
+    'up' => static function (Builder $schema) {
         $schema->table('post_reactions', function (Blueprint $table) {
             // Speeds up getActorReactionForPost() and setReaction() lookups
             $table->index(['post_id', 'user_id'], 'post_reactions_post_id_user_id_index');
@@ -29,13 +29,20 @@ return [
         });
     },
 
-    'down' => function (Builder $schema) {
+    'down' => static function (Builder $schema) {
         $schema->table('post_reactions', function (Blueprint $table) {
+            // Recreate single-column foreign-key index (post_id foreign index) that was automatically dropped by DB when
+            // the multi-column indexes were created. Otherwise, we hit a FK constraint error.
+            $table->index(['post_id'], 'post_reactions_post_id_foreign');
+
             $table->dropIndex('post_reactions_post_id_user_id_index');
             $table->dropIndex('post_reactions_post_id_reaction_id_index');
         });
 
         $schema->table('post_anonymous_reactions', function (Blueprint $table) {
+            // Same as above
+            $table->index(['post_id'], 'post_anonymous_reactions_post_id_foreign');
+
             $table->dropIndex('post_anonymous_reactions_post_id_guest_id_index');
             $table->dropIndex('post_anonymous_reactions_post_id_reaction_id_index');
         });

--- a/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
+++ b/migrations/2026_03_22_000000_add_indexes_to_reaction_tables.php
@@ -30,18 +30,22 @@ return [
     },
 
     'down' => static function (Builder $schema) {
-        $schema->table('post_reactions', function (Blueprint $table) {
+        $schema->table('post_reactions', function (Blueprint $table) use ($schema) {
             // Recreate single-column foreign-key index (post_id foreign index) that was automatically dropped by DB when
             // the multi-column indexes were created. Otherwise, we hit a FK constraint error.
-            $table->index(['post_id'], 'post_reactions_post_id_foreign');
+            if (! $schema->hasIndex('post_reactions', $foreignIndex = 'post_reactions_post_id_foreign')) {
+                $table->index(['post_id'], $foreignIndex);
+            }
 
             $table->dropIndex('post_reactions_post_id_user_id_index');
             $table->dropIndex('post_reactions_post_id_reaction_id_index');
         });
 
-        $schema->table('post_anonymous_reactions', function (Blueprint $table) {
-            // Same as above
-            $table->index(['post_id'], 'post_anonymous_reactions_post_id_foreign');
+        $schema->table('post_anonymous_reactions', function (Blueprint $table) use ($schema) {
+            // Same as above, but for anonymous reactions.
+            if (! $schema->hasIndex('post_anonymous_reactions', $foreignIndex = 'post_anonymous_reactions_post_id_foreign')) {
+                $table->index(['post_id'], $foreignIndex);
+            }
 
             $table->dropIndex('post_anonymous_reactions_post_id_guest_id_index');
             $table->dropIndex('post_anonymous_reactions_post_id_reaction_id_index');

--- a/tests/integration/db/MigrationsTest.php
+++ b/tests/integration/db/MigrationsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FoF\Reactions\Tests\integration\db;
+
+use Flarum\Extension\ExtensionManager;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class MigrationsTest extends TestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-reactions');
+    }
+
+    #[Test]
+    public function it_rolls_back_migrations_without_errors(): void
+    {
+        // Boot the app so the extension is installed and migrated.
+        $this->app();
+
+        // Run down migrations for fof/reactions -- should not throw any exceptions.
+        $extensionManager = resolve(ExtensionManager::class);
+        $extensionManager->uninstall('fof-reactions');
+
+        // If no error occurred, the test will pass.
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/integration/db/MigrationsTest.php
+++ b/tests/integration/db/MigrationsTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/reactions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Reactions\Tests\integration\db;
 
 use Flarum\Extension\ExtensionManager;
@@ -8,7 +17,6 @@ use PHPUnit\Framework\Attributes\Test;
 
 class MigrationsTest extends TestCase
 {
-
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
     colors="true"
     processIsolation="true"
     stopOnFailure="false"
+    cacheDirectory=".phpunit.cache"
 >
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">../src/</directory>
-        </include>
-    </coverage>
     <testsuites>
         <testsuite name="Flarum Integration Tests">
             <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
+            <exclude>./integration/tmp</exclude>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">../src/</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
+    cacheDirectory=".phpunit.cache"
 >
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">../src/</directory>
-        </include>
-    </coverage>
     <testsuites>
         <testsuite name="Flarum Unit Tests">
             <directory suffix="Test.php">./unit</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">../src/</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

Fixes #113 

**Changes proposed in this pull request:**
- add simple integration test that calls `$extensionManager->uninstall` to ensure the uninstall process works for the extension
- migrate `phpunit.integration.xml` and `phpunit.unit.xml` configs using `phpunit --migrate-configuration` to reduce deprecations
- update indexes migration to re-add single `post_id` foreign index before dropping the tuple indexes
  -  When the multi-column (post_id, user_id) and (post_id, reaction_id) indexes are created during UP migration, databases such as MySQL optimize by removing the `post_id` foreign index. This creates an error when we try to drop those indexes, as it gets rid of the foreign key index. This change puts it back.

The indexes _before_ the migration is ran:
```
post_reactions_post_id_foreign BTREE FALSE post_id
post_reactions_reaction_id_foreign BTREE FALSE reaction_id
post_reactions_user_id_foreign BTREE FALSE user_id
PRIMARY BTREE TRUE i
```

The indexes _after_ the migration is ran:
```
post_reactions_post_id_reaction_id_index BTREE FALSE post_id,reaction_id
post_reactions_post_id_user_id_index BTREE FALSE post_id,user_id
post_reactions_reaction_id_foreign BTREE FALSE reaction_id
post_reactions_user_id_foreign BTREE FALSE user_id
PRIMARY BTREE TRUE i
```

You can see the individual `post_id` foreign index was replaced with the two we created.

**Reviewers should focus on:**
Not sure if this could happen with the other columns (user_id and reaction_id) -- it doesn't seem to. Down migrations work fine now. You can compare the test runs from before and after the migration fix.

I also could not reproduce this in my installation but I could with `composer test:integration` on the same DB service, which is weird. My normal Flarum installation purged just fine.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
